### PR TITLE
Support capture groups in :append and :prepend mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-patch (0.3.0)
+    fastlane-plugin-patch (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ patch(
 
 #### Capture groups
 
-Capture groups may be used in `:replace` mode.
+Capture groups may be used within the text argument in any mode. Note that
+this works best without interpolation (single quotes or %q). If you use double
+quotes, the backslash must be escaped, e.g. `text: "\\1\"MyOtherpod\""`.
 
 ```Ruby
 patch(
@@ -71,7 +73,9 @@ patch(
   text: '\1"MyOtherPod"',
   mode: :replace
 )
-```
+
+Patches in `:append` mode using capture groups in the text argument may be
+reverted. This is not currently supported in `:prepend` mode.
 
 #### Revert patches
 

--- a/lib/fastlane/plugin/patch/version.rb
+++ b/lib/fastlane/plugin/patch/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Patch
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
`:prepend` patches using capture groups in the `:text` argument cannot currently be reverted (at least not successfully).